### PR TITLE
HTTP Post/Get key retrieving 

### DIFF
--- a/src/Helpers/Http.php
+++ b/src/Helpers/Http.php
@@ -53,13 +53,15 @@ class Http
      * @param string $type The type of data
      * @param boolean $htmlentities (default: false) If use htmlentities
      *  function to a better security
+     * @param boolean $inline (default: true) If array data are inline
      * 
      * @return mixed
      */
     public static function obtainPostKey(
         string $key,
         string $type,
-        bool $htmlentities = false
+        bool $htmlentities = false,
+        bool $inline = true
     ) {
         $currentClass = get_called_class();
         $secure       = $currentClass::getSecureHelpersName();
@@ -68,7 +70,8 @@ class Http
             $_POST,
             $key,
             $type,
-            $htmlentities
+            $htmlentities,
+            $inline
         );
     }
 
@@ -79,13 +82,15 @@ class Http
      * @param string $type The type of data
      * @param boolean $htmlentities (default: false) If use htmlentities
      *  function to a better security
+     * @param boolean $inline (default: true) If array data are inline
      * 
      * @return mixed
      */
     public static function obtainGetKey(
         string $key,
         string $type,
-        bool $htmlentities = false
+        bool $htmlentities = false,
+        bool $inline = true
     ) {
         $currentClass = get_called_class();
         $secure       = $currentClass::getSecureHelpersName();
@@ -94,7 +99,8 @@ class Http
             $_GET,
             $key,
             $type,
-            $htmlentities
+            $htmlentities,
+            $inline
         );
     }
     

--- a/src/Helpers/Secure.php
+++ b/src/Helpers/Secure.php
@@ -184,11 +184,6 @@ class Secure
         
         if (!$inline) {
             $data = trim($array[$key], ' \0\x0B');
-            //$data = trim($array[$key]);
-            //$data = $array[$key];
-            
-            echo('not inline');
-            var_dump($data);
         } else {
             $data = trim($array[$key]);
         }

--- a/src/Helpers/Secure.php
+++ b/src/Helpers/Secure.php
@@ -72,27 +72,23 @@ class Secure
      * We work the data like if the type is a string.
      * 
      * @param mixed $data The variable to securise
+     * @param string $type The type of datas
      * @param boolean $htmlentities If use htmlentities function
      *  to a better security
      * 
      * @return mixed
      */
-    public static function secureUnknownType($data, bool $htmlentities)
+    public static function secureUnknownType($data, string $type, bool $htmlentities)
     {
-        $currentClass    = get_called_class();
-        $sqlSecureMethod = $currentClass::getSqlSecureMethod();
-        
-        if ($sqlSecureMethod !== null) {
-            $data = $sqlSecureMethod($data);
-        } else {
-            $data = addslashes($data);
-        }
-
-        if ($htmlentities === true) {
-            $data = htmlentities($data, ENT_COMPAT | ENT_HTML401);
+        if ($type !== 'html') {
+            $data = strip_tags($data);
         }
         
-        return $data;
+        if ($type === 'html' || $htmlentities === true) {
+            return htmlentities($data, ENT_QUOTES | ENT_HTML401);
+        }
+        
+        return addslashes($data);
     }
 
     /**
@@ -133,7 +129,7 @@ class Secure
             //Else : Use securise like if it's a text type
         }
 
-        return $currentClass::secureUnknownType($data, $htmlentities);
+        return $currentClass::secureUnknownType($data, $type, $htmlentities);
     }
 
     /**
@@ -148,7 +144,7 @@ class Secure
             'sqlSecureMethod',
             'global.php'
         );
-
+        
         if (!is_callable($secureFct, false)) {
             return null;
         }
@@ -164,6 +160,7 @@ class Secure
      * @param string $type The type of data
      * @param boolean $htmlentities (default: false) If use htmlentities
      *  function to a better security
+     * @param boolean $inline (default: true) If array data are inline
      * 
      * @return mixed
      * 
@@ -173,7 +170,8 @@ class Secure
         array &$array,
         string $key,
         string $type,
-        bool $htmlentities = false
+        bool $htmlentities = false,
+        bool $inline = true
     ) {
         if (!isset($array[$key])) {
             throw new Exception(
@@ -183,8 +181,20 @@ class Secure
         }
 
         $currentClass = get_called_class();
+        
+        if (!$inline) {
+            $data = trim($array[$key], ' \0\x0B');
+            //$data = trim($array[$key]);
+            //$data = $array[$key];
+            
+            echo('not inline');
+            var_dump($data);
+        } else {
+            $data = trim($array[$key]);
+        }
+        
         return $currentClass::secureData(
-            trim($array[$key]),
+            $data,
             $type,
             $htmlentities
         );
@@ -197,9 +207,10 @@ class Secure
      * @param array $keysList The key list to obtain.
      *  For each item, the key is the name of the key in source array; And the
      *  value the type of the value. The value can also be an object. In this
-     *  case, the properties "type" contain the value type, and the "htmlenties"
+     *  case, the properties "type" contain the value type, the "htmlenties"
      *  property contain the boolean who indicate if secure system 
-     *  will use htmlentities.
+     *  will use htmlentities, and the "inline" property contain the boolean who 
+     *  indicate if data are inline
      * @param boolean $throwOnError (defaut true) If a key not exist, throw an
      *  exception. If false, the value will be null into returned array
      * 
@@ -219,7 +230,8 @@ class Secure
             if (!is_array($infos)) {
                 $infos = [
                     'type'         => $infos,
-                    'htmlentities' => false
+                    'htmlentities' => false,
+                    'inline'       => true
                 ];
             }
             
@@ -228,7 +240,8 @@ class Secure
                     $arraySrc,
                     $keyName,
                     $infos['type'],
-                    $infos['htmlentities']
+                    $infos['htmlentities'],
+                    $infos['inline']
                 );
             } catch (Exception $ex) {
                 if ($throwOnError === true) {


### PR DESCRIPTION
Add $inline parameter into key retrieving methods to determine if a key should be inline trimed or not (can be replaced by a type checking, but not sure it worth it because sometimes a simple text or html code can be inline too)

Add $type parameter into secureUnknownType

Add type managment into secureUnknownType as 'htlm' type need a special process

Add strip_tags() method to securise data that are not html data

Force addslashes() use instead of SqlSecureMethod call into secure methods. We don't need SqlSecureMethod, as we don't know what it does (it's part of SGBDR) and as securing http data is not part of SQL process as we do not use that data into a SQL treatment for now. SQL protect/quote should only be used with SQL treatment. It's bfw-sql (or other sql module) purpose.